### PR TITLE
Checked consistency between tractrography and dissimilarity

### DIFF
--- a/tractome.py
+++ b/tractome.py
@@ -260,7 +260,7 @@ class Tractome(object):
 
         try:
             assert(self.full_dissimilarity_matrix.shape[0] == len(self.T))
-        except AttributeError:
+        except AssertionError:
             print "Re-computing dissimilarity matrix."
             self.num_prototypes = 40
             self.full_dissimilarity_matrix = compute_dissimilarity(self.T, distance=bundles_distances_mam, prototype_policy='sff', num_prototypes=self.num_prototypes)


### PR DESCRIPTION
I added a check of the size of the tractography with respect to that of the dissimilarity representation. If there is a mismatch, the dissimilarity is re-computed and re-saved.

Moreover I added a couple of lines so that the cache is saved only when necessary. Previously it was saved every time, which is unnecessary and pretty slow for large tractographies.
