### PR TITLE
Moving Show Tractography option as Toggle Tractography in View Menu

### DIFF
--- a/Ui_mainwindow.py
+++ b/Ui_mainwindow.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
-#
-# Created: Tue Dec  9 16:12:11 2014
+# Created: Mon Dec 22 10:19:16 2014
 #      by: pyside-uic 0.2.13 running on PySide 1.1.0
 #
 # WARNING! All changes made in this file will be lost!
@@ -251,20 +249,6 @@ class Ui_MainWindow(object):
         self.horizontalLayout_4.addWidget(self.tblROISlist)
         self.tabProps_4.addTab(self.tab, "")
         self.verticalLayout_2.addWidget(self.tabProps_4)
-        self.horizontalLayout_28 = QtGui.QHBoxLayout()
-        self.horizontalLayout_28.setObjectName("horizontalLayout_28")
-        self.chkbShowTract = QtGui.QCheckBox(self.centralWidget)
-        self.chkbShowTract.setEnabled(False)
-        self.chkbShowTract.setChecked(True)
-        self.chkbShowTract.setTristate(False)
-        self.chkbShowTract.setObjectName("chkbShowTract")
-        self.horizontalLayout_28.addWidget(self.chkbShowTract)
-        self.chkbShowStruct = QtGui.QCheckBox(self.centralWidget)
-        self.chkbShowStruct.setEnabled(False)
-        self.chkbShowStruct.setChecked(True)
-        self.chkbShowStruct.setObjectName("chkbShowStruct")
-        self.horizontalLayout_28.addWidget(self.chkbShowStruct)
-        self.verticalLayout_2.addLayout(self.horizontalLayout_28)
         self.verticalLayout = QtGui.QVBoxLayout()
         self.verticalLayout.setObjectName("verticalLayout")
         self.grbROImethod = QtGui.QGroupBox(self.centralWidget)
@@ -347,6 +331,7 @@ class Ui_MainWindow(object):
         self.horizontalLayout_5 = QtGui.QHBoxLayout()
         self.horizontalLayout_5.setObjectName("horizontalLayout_5")
         self.spbExtClust = QtGui.QSpinBox(self.grbExtendcluster)
+        self.spbExtClust.setEnabled(False)
         self.spbExtClust.setReadOnly(False)
         self.spbExtClust.setMinimum(0)
         self.spbExtClust.setObjectName("spbExtClust")
@@ -479,6 +464,8 @@ class Ui_MainWindow(object):
         self.actionSaggital_Slice.setObjectName("actionSaggital_Slice")
         self.actionCoronal_Slice = QtGui.QAction(MainWindow)
         self.actionCoronal_Slice.setObjectName("actionCoronal_Slice")
+        self.actionToggle = QtGui.QAction(MainWindow)
+        self.actionToggle.setObjectName("actionToggle")
         self.menuFile.addAction(self.actionLoad_Structural_Image)
         self.menuFile.addAction(self.actionLoad_Tractography)
         self.menuFile.addAction(self.actionLoad_Saved_Segmentation)
@@ -510,6 +497,7 @@ class Ui_MainWindow(object):
         self.menu3D_Slicer.addAction(self.actionMove_Down_Down)
         self.menuHistory.addAction(self.actionBack_B)
         self.menuHistory.addAction(self.actionForward_F)
+        self.menuTractography.addAction(self.actionToggle)
         self.menuTractography.addAction(self.actionPick_Representative_P)
         self.menuTractography.addAction(self.actionInvert)
         self.menuTractography.addAction(self.actionRemove_Selected_Back_Space)
@@ -559,8 +547,6 @@ class Ui_MainWindow(object):
         self.tblROI.setSortingEnabled(__sortingEnabled)
         self.tabProps_4.setTabText(self.tabProps_4.indexOf(self.tabPropsROI), QtGui.QApplication.translate("MainWindow", "ROI Properties", None, QtGui.QApplication.UnicodeUTF8))
         self.tabProps_4.setTabText(self.tabProps_4.indexOf(self.tab), QtGui.QApplication.translate("MainWindow", "Applied ROIS", None, QtGui.QApplication.UnicodeUTF8))
-        self.chkbShowTract.setText(QtGui.QApplication.translate("MainWindow", "Show Tractography", None, QtGui.QApplication.UnicodeUTF8))
-        self.chkbShowStruct.setText(QtGui.QApplication.translate("MainWindow", "Show Structural Image", None, QtGui.QApplication.UnicodeUTF8))
         self.grbROImethod.setTitle(QtGui.QApplication.translate("MainWindow", "ROI Method", None, QtGui.QApplication.UnicodeUTF8))
         self.rdbInsSphere.setText(QtGui.QApplication.translate("MainWindow", "Inside Sphere", None, QtGui.QApplication.UnicodeUTF8))
         self.rdbtrackvis.setText(QtGui.QApplication.translate("MainWindow", "Trackvis Like", None, QtGui.QApplication.UnicodeUTF8))
@@ -587,10 +573,10 @@ class Ui_MainWindow(object):
         self.actionExpand_Clusters.setText(QtGui.QApplication.translate("MainWindow", "Expand Clusters", None, QtGui.QApplication.UnicodeUTF8))
         self.actionSave_as_trackvis_file.setText(QtGui.QApplication.translate("MainWindow", "Save as trackvis file", None, QtGui.QApplication.UnicodeUTF8))
         self.actionScreen.setText(QtGui.QApplication.translate("MainWindow", "Screen", None, QtGui.QApplication.UnicodeUTF8))
-        self.actionPick_Representative_P.setText(QtGui.QApplication.translate("MainWindow", "Pick Representative                      P", None, QtGui.QApplication.UnicodeUTF8))
+        self.actionPick_Representative_P.setText(QtGui.QApplication.translate("MainWindow", "Pick Representative                       P", None, QtGui.QApplication.UnicodeUTF8))
         self.actionHide_Representative_H.setText(QtGui.QApplication.translate("MainWindow", "Hide Representatives                    H", None, QtGui.QApplication.UnicodeUTF8))
         self.actionSelect_All_Representatives_A.setText(QtGui.QApplication.translate("MainWindow", "Select All Representatives           A", None, QtGui.QApplication.UnicodeUTF8))
-        self.actionInvert.setText(QtGui.QApplication.translate("MainWindow", "Invert Selection                               I", None, QtGui.QApplication.UnicodeUTF8))
+        self.actionInvert.setText(QtGui.QApplication.translate("MainWindow", "Invert Selection                                I", None, QtGui.QApplication.UnicodeUTF8))
         self.actionExpan_Selection_E.setText(QtGui.QApplication.translate("MainWindow", "Expand Selection                            E", None, QtGui.QApplication.UnicodeUTF8))
         self.actionRemove_Selected_Back_Space.setText(QtGui.QApplication.translate("MainWindow", "Remove UnSelected                Backspace", None, QtGui.QApplication.UnicodeUTF8))
         self.actionBack_B.setText(QtGui.QApplication.translate("MainWindow", "Back                 B", None, QtGui.QApplication.UnicodeUTF8))
@@ -608,7 +594,4 @@ class Ui_MainWindow(object):
         self.actionAxial_Slice.setText(QtGui.QApplication.translate("MainWindow", "Axial Slice", None, QtGui.QApplication.UnicodeUTF8))
         self.actionSaggital_Slice.setText(QtGui.QApplication.translate("MainWindow", "Saggital Slice", None, QtGui.QApplication.UnicodeUTF8))
         self.actionCoronal_Slice.setText(QtGui.QApplication.translate("MainWindow", "Coronal Slice", None, QtGui.QApplication.UnicodeUTF8))
-
-
-
-
+        self.actionToggle.setText(QtGui.QApplication.translate("MainWindow", "Toggle                                                 T", None, QtGui.QApplication.UnicodeUTF8))

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -586,39 +586,6 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_28">
-        <item>
-         <widget class="QCheckBox" name="chkbShowTract">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Show Tractography</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="tristate">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="chkbShowStruct">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Show Structural Image</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
          <widget class="QGroupBox" name="grbROImethod">
@@ -947,6 +914,7 @@
       <addaction name="actionBack_B"/>
       <addaction name="actionForward_F"/>
      </widget>
+     <addaction name="actionToggle"/>
      <addaction name="actionPick_Representative_P"/>
      <addaction name="actionInvert"/>
      <addaction name="actionRemove_Selected_Back_Space"/>
@@ -1044,7 +1012,7 @@
   </action>
   <action name="actionPick_Representative_P">
    <property name="text">
-    <string>Pick Representative                      P</string>
+    <string>Pick Representative                       P</string>
    </property>
    <property name="toolTip">
     <string notr="true">Pick Representative                        P</string>
@@ -1068,7 +1036,7 @@
   </action>
   <action name="actionInvert">
    <property name="text">
-    <string>Invert Selection                               I</string>
+    <string>Invert Selection                                I</string>
    </property>
   </action>
   <action name="actionExpan_Selection_E">
@@ -1154,6 +1122,11 @@
   <action name="actionCoronal_Slice">
    <property name="text">
     <string>Coronal Slice</string>
+   </property>
+  </action>
+  <action name="actionToggle">
+   <property name="text">
+    <string>Toggle                                                 T</string>
    </property>
   </action>
  </widget>

--- a/streamshow.py
+++ b/streamshow.py
@@ -256,6 +256,7 @@ class StreamlineLabeler(Actor, Manipulator):
 
         self.hide_representatives = False
         self.expand = False
+        self.expanded = False
         self.knnreset = False
         self.representatives_line_width = representatives_line_width
         self.streamlines_line_width = streamlines_line_width
@@ -507,6 +508,18 @@ class StreamlineLabeler(Actor, Manipulator):
         elif symbol == Qt.Key_F:
             print "Go one step Forward in the history."
             self.simple_history_forward_one_step()
+            
+        elif symbol == Qt.Key_T:
+            print 'T: Hide/show the whole tractography.'
+            self.hide_representatives = not self.hide_representatives
+            if self.hide_representatives :
+                if self.expand :
+                    self.expanded = True
+                    self.expand = False
+
+            if not self.hide_representatives and self.expanded:
+                self.expand = True
+                self.expanded = False
 
 
     def get_pointed_representative(self, min_dist=1e-3):

--- a/tractome.py
+++ b/tractome.py
@@ -54,7 +54,7 @@ class Tractome(object):
         self.list_oper_ROIS = []
      
      
-    def loading_structural(self, structpath = None):
+    def loading_structural(self, structpath = None,  actor_name = 'Volume Slicer'):
         """
         Loading structural data.
         """
@@ -75,11 +75,11 @@ class Tractome(object):
         
         # Create the Guillotine object
         data = (np.interp(data, [data.min(), data.max()], [0, 255]))
-        self.guil = Guillotine('Volume Slicer', data, np.copy(self.affine))
+        self.guil = Guillotine(actor_name, data, np.copy(self.affine))
         self.scene.add_actor(self.guil) 
     
         
-    def loading_full_tractograpy(self, tracpath=None):
+    def loading_full_tractograpy(self, tracpath=None, actor_name = 'Bundle Picker'):
         """
         Loading full tractography and creates StreamlineLabeler to
         show it all.
@@ -123,7 +123,7 @@ class Tractome(object):
             self.update_info(general_info_filename)
                     
         # create the interaction system for tracks, 
-        self.streamlab  = StreamlineLabeler('Bundle Picker',
+        self.streamlab  = StreamlineLabeler(actor_name,
                                             self.buffers, self.clusters,
                                             vol_shape=self.dims, 
                                             affine=np.copy(self.affine),


### PR DESCRIPTION
As the options for manipulating the 3DSlicer and StreamlineLabeler (tractography) through keys were included in a View Menu, the Show Tractography option was also moved to this Menu.
This is also a workaround for  PR#13, which was closed.
