### PR TITLE
BF: .tck files working

### DIFF
--- a/tractome/app.py
+++ b/tractome/app.py
@@ -113,7 +113,7 @@ class Tractome(QMainWindow):
     def _init_actors(self):
         """Initialize the actors for the scene."""
         if self.tractogram:
-            self._sft = read_tractogram(self.tractogram)
+            self._sft = read_tractogram(self.tractogram, reference=self.t1)
             if (
                 self._sft.data_per_streamline is None
                 or "dismatrix" not in self._sft.data_per_streamline

--- a/tractome/cli.py
+++ b/tractome/cli.py
@@ -1,6 +1,6 @@
 import click
-import numpy as np
 from dipy.tracking.distances import bundles_distances_mam, bundles_distances_mdf
+import numpy as np
 
 from tractome.app import Tractome
 from tractome.compute import compute_dissimilarity
@@ -43,10 +43,18 @@ def tractome(tractogram=None, mesh=None, mesh_texture=None, t1=None):
     type=click.Path(exists=True),
 )
 @click.option(
+    "--reference",
+    type=click.Path(exists=True),
+    help="Path to the reference image file.",
+)
+@click.option(
     "--distance",
     type=click.Choice(["bundles_distances_mam", "bundles_distances_mdf"]),
     default="bundles_distances_mam",
-    help="Distance metric to use. Must be one of ['bundles_distances_mam', 'bundles_distances_mdf'].",
+    help=(
+        "Distance metric to use. Must be one of ['bundles_distances_mam',"
+        "'bundles_distances_mdf']."
+    ),
 )
 @click.option(
     "--prototype_policy",
@@ -72,10 +80,13 @@ def tractome(tractogram=None, mesh=None, mesh_texture=None, t1=None):
     "--output_file",
     type=click.Path(),
     default="computed.trx",
-    help="File path to save the computed dissimilarity matrix along with the tractogram.",
+    help=(
+        "File path to save the computed dissimilarity matrix along with the tractogram."
+    ),
 )
 def compute_dissimilarity_matrix(
     tractogram_path,
+    reference=None,
     distance="bundles_distances_mam",
     prototype_policy="sff",
     num_prototypes=40,
@@ -90,6 +101,8 @@ def compute_dissimilarity_matrix(
     ----------
     tractogram_path : str
         The path to the tractogram file.
+    reference : str, optional
+        The path to the reference image file.
     distance : str, optional
         The distance metric to use.
     prototype_policy : str, optional
@@ -104,7 +117,8 @@ def compute_dissimilarity_matrix(
     n_jobs : int, optional
         The number of parallel jobs to run.
     output_file : str, optional
-        The file path to save the computed dissimilarity matrix along with the tractogram.
+        The file path to save the computed dissimilarity matrix along with the
+        tractogram.
 
     Raises
     ------
@@ -113,7 +127,7 @@ def compute_dissimilarity_matrix(
     ValueError
         The prototype selection policy to use.
     """
-    sft = read_tractogram(tractogram_path)
+    sft = read_tractogram(tractogram_path, reference=reference)
 
     if distance == "bundles_distances_mam":
         distance = bundles_distances_mam
@@ -121,12 +135,14 @@ def compute_dissimilarity_matrix(
         distance = bundles_distances_mdf
     else:
         raise ValueError(
-            f"Unknown distance metric: {distance}, must be one of ['bundles_distances_mam', 'bundles_distances_mdf']"
+            f"Unknown distance metric: {distance}, must be one of "
+            "['bundles_distances_mam', 'bundles_distances_mdf']"
         )
 
     if prototype_policy not in ["random", "fft", "sff"]:
         raise ValueError(
-            f"Unknown prototype policy: {prototype_policy}, must be one of ['random', 'fft', 'sff']"
+            f"Unknown prototype policy: {prototype_policy},"
+            "must be one of ['random', 'fft', 'sff']"
         )
 
     data_dissimilarity = compute_dissimilarity(

--- a/tractome/io.py
+++ b/tractome/io.py
@@ -31,7 +31,7 @@ def validate_path(path):
         raise FileNotFoundError(f"The file {path} does not exist or is not a file.")
 
 
-def read_tractogram(file_path):
+def read_tractogram(file_path, reference=None):
     """Read a tractogram file.
 
     Parameters
@@ -48,7 +48,18 @@ def read_tractogram(file_path):
     validated_path = validate_path(file_path)
     logging.info(f"Loading tractogram from {validated_path} ...")
 
-    sft = load_tractogram(validated_path, "same", bbox_valid_check=False)
+    if reference is None:
+        if validated_path.endswith((".trk", ".trx")):
+            reference = "same"
+        else:
+            raise ValueError(
+                "Reference image must be provided for files other than "
+                ".trk and .trx files."
+            )
+
+    sft = load_tractogram(validated_path, reference, bbox_valid_check=False)
+    if not sft:
+        raise ValueError(f"Failed to load tractogram from {validated_path}.")
 
     if sft.data_per_streamline is not None and "dismatrix" in sft.data_per_streamline:
         logging.info("Dissimilarity matrix already present in the tractogram data.")


### PR DESCRIPTION
### BF: .tck files working

**Issues**
#29 Fail to load tck files.

**PR Contents**

- Introduced message for `.tck` files to provide reference.
- `--reference` option added in `tractome_compute_dismatrix` cli.
- Tested for provided data.

**Visuals**
<img width="437" height="618" alt="Screenshot 2025-09-16 at 9 37 02 PM" src="https://github.com/user-attachments/assets/19dfb774-2833-4df2-a4b8-5e51f81beb99" />

<img width="411" height="626" alt="Screenshot 2025-09-16 at 9 37 36 PM" src="https://github.com/user-attachments/assets/73b40fd8-5b81-4cd3-bd9c-4f7ee55c6f55" />

