### PR TITLE
ENH: Dragging will not conflict with selection.

### DIFF
--- a/tractome/viz.py
+++ b/tractome/viz.py
@@ -141,6 +141,31 @@ def _toggle_streamtube_selection(streamtube):
         _select_streamtube(streamtube)
 
 
+def _register_streamtube_focus(event):
+    """Handle focus events on streamtubes.
+
+    Parameters
+    ----------
+    event : Event
+        The focus event.
+    """
+    st = event.target
+    st.is_clicked = True
+
+
+def _register_streamtube_out_focus(event):
+    """Handle out-focus events on streamtubes.
+
+    Parameters
+    ----------
+    event : Event
+        The out-focus event.
+    """
+    st = event.target
+    if hasattr(st, "is_clicked") and st.is_clicked:
+        st.is_clicked = False
+
+
 def toggle_streamtube_selection(event):
     """Handle click events on streamtubes.
 
@@ -149,9 +174,11 @@ def toggle_streamtube_selection(event):
     event : Event
         The click event.
     """
-
     st = event.target
-    _toggle_streamtube_selection(st)
+    if hasattr(st, "is_clicked") and st.is_clicked:
+        # _register_streamtube_out_focus(event)
+        st.is_clicked = False
+        _toggle_streamtube_selection(st)
 
 
 def create_streamtube(clusters, streamlines):
@@ -195,7 +222,9 @@ def create_streamtube(clusters, streamlines):
         streamtube.rep = rep
         streamtube.material.opacity = 0.5
         streamtube.material.uniform_buffer.update_full()
-        streamtube.add_event_handler(toggle_streamtube_selection, "pointer_down")
+        streamtube.add_event_handler(_register_streamtube_focus, "on_focus")
+        streamtube.add_event_handler(_register_streamtube_out_focus, "out_focus")
+        streamtube.add_event_handler(toggle_streamtube_selection, "pointer_up")
         streamtubes[rep] = streamtube
 
     return streamtubes


### PR DESCRIPTION
### ENH: Dragging will not conflict with selection.

**PR Contents**
- We created a event based mechanism to track the focus.
- A streamtube is marked if pointer down.
- It will be unmarked with pointer up on other actor.
- Complete the action if pointer up on the same actor.

Closes  #34 Clash of picking and rotation  gesture