### PR TITLE
BF: CLI passes Tractome() args by keyword.

### DIFF
--- a/tractome/cli.py
+++ b/tractome/cli.py
@@ -51,7 +51,14 @@ def tractome(
     parcel : str, optional
         Path to a parcel CSV file
     """
-    tractome = Tractome(tractogram, mesh, mesh_texture, t1, roi, parcel)
+    tractome = Tractome(
+        tractogram=tractogram,
+        t1=t1,
+        mesh=mesh,
+        mesh_texture=mesh_texture,
+        roi=roi,
+        parcel=parcel,
+    )
     tractome.start()
 
 


### PR DESCRIPTION
- Positional binding misrouted --mesh, --mesh_texture, --t1 after the Tractome.__init__ parameter reorder.
- Pass tractogram/t1/mesh/mesh_texture/roi/parcel by keyword.